### PR TITLE
Handle leaking file handle if png.Decode/Encode fail

### DIFF
--- a/services/receipts/src/receipts/img.go
+++ b/services/receipts/src/receipts/img.go
@@ -73,10 +73,21 @@ func serveImg(db *pg.DB) routes.HandlerFunc {
 
 		img, err := png.Decode(file)
 		if err != nil {
+			// don't check the error on Close because we will end up masking the actual Decode error
+			file.Close()
 			log.Fatal(err)
 		}
-		file.Close()
 
-		png.Encode(w, img)
+		if err := png.Encode(w, img); err != nil {
+			// don't check the error on Close because we will end up masking the actual Encode error
+			file.Close()
+			log.Fatal(err)
+		}
+		
+		// closing a file can error
+		// https://joeshaw.org/dont-defer-close-on-writable-files/
+		if err := file.Close(); err != nil {
+			log.Fatal(err)
+		}
 	}
 }


### PR DESCRIPTION
https://joeshaw.org/dont-defer-close-on-writable-files/ brings up a great point imo. Closing a file can fail, and it is probably something someone checking logs would want to know. Also it is probably worth checking the error on `png.Encode`. Maybe you don't want to `log.Fatal`, and instead use `log.Error()`.